### PR TITLE
scrollTop based on logical expression

### DIFF
--- a/placetobe-campaign-page.html
+++ b/placetobe-campaign-page.html
@@ -578,7 +578,8 @@ Placetobe Campaign Page
       },
 
       _setScrollPositions: function(evt) {
-        this._scrollY = window.document.body.scrollTop;
+        var scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+        this._scrollY = scrollTop;
         this._navigationBarY = this.$.navigationBar.offsetTop;
       },
 

--- a/placetobe-campaign-page.html
+++ b/placetobe-campaign-page.html
@@ -578,7 +578,7 @@ Placetobe Campaign Page
       },
 
       _setScrollPositions: function(evt) {
-        var scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop || 0;
+        var scrollTop = window.pageYOffset || window.document.documentElement.scrollTop || window.document.body.scrollTop || 0;
         this._scrollY = scrollTop;
         this._navigationBarY = this.$.navigationBar.offsetTop;
       },


### PR DESCRIPTION
window.document.body.scrollTop stayed 0 in Chrome.

Tested on FF, Safari, Edge & Chrome. Not tested on mobile.